### PR TITLE
feat: support header/footer code for JavaScript

### DIFF
--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -1,5 +1,8 @@
 import { SET_CODE, RUN_CODE_FAILED } from '../types';
-import { runJavaScript } from '../runners/javascript';
+import {
+  runJavaScript,
+  runJavaScriptWithHeaderAndFooter,
+} from '../runners/javascript';
 import { JAVASCRIPT, PYTHON } from '../config/programmingLanguages';
 import { runPython } from '../runners/python';
 
@@ -13,7 +16,7 @@ const runCode = data => (dispatch, getState) => {
   const {
     appInstance: {
       content: {
-        settings: { programmingLanguage },
+        settings: { programmingLanguage, headerCode, footerCode },
       },
     },
   } = getState();
@@ -23,6 +26,13 @@ const runCode = data => (dispatch, getState) => {
         runPython(data, dispatch);
         break;
       case JAVASCRIPT:
+        runJavaScriptWithHeaderAndFooter(
+          headerCode,
+          data,
+          footerCode,
+          dispatch
+        );
+        break;
       default:
         runJavaScript(data, dispatch);
     }

--- a/src/runners/javascript.js
+++ b/src/runners/javascript.js
@@ -8,8 +8,16 @@ const sanitize = code => {
   return code;
 };
 
+// We would like to use module type worker, but Firefox still does not support that (16/8/2019).
+const workerOptions = {
+  type: 'classic',
+};
+
 function createWorker(dispatch) {
-  const worker = new Worker(`data://application/javascript,${workerCode}`);
+  const worker = new Worker(
+    `data://application/javascript,${workerCode}`,
+    workerOptions
+  );
   worker.onmessage = ev => {
     switch (ev.data.cmd) {
       case PRINT:
@@ -36,4 +44,23 @@ const runJavaScript = (code = '', dispatch) => {
   worker.postMessage(code);
 };
 
-export { sanitize, runJavaScript };
+// Header code is intended to be used for importing libraries, initialize screens, and so on.
+// Footer code is intended to be used for display runnning status, free resources, and so on.
+const runJavaScriptWithHeaderAndFooter = (
+  headerCode = '',
+  code = '',
+  footerCode = '',
+  dispatch
+) => {
+  const worker = createWorker(dispatch);
+  if (headerCode) {
+    worker.postMessage(headerCode);
+  }
+
+  worker.postMessage(code);
+
+  if (footerCode) {
+    worker.postMessage(footerCode);
+  }
+};
+export { sanitize, runJavaScript, runJavaScriptWithHeaderAndFooter };


### PR DESCRIPTION
To support using external libraries easily, I added header/footer code feature for JavaScript. 

Header code is intended to be used for importing libraries, initialize screen, and so on.
Footer code is intended to be used to display runnning status, free resources, and so on.

For example, once teacher configures header/footer codes as follows, students
can use math.js from the beginning and outout terminals is automatically refreshed.

    Example usage of header/footer codes

        header code:
    		importScripts("https://cdnjs.cloudflare.com/ajax/libs/mathjs/6.1.0/math.min.js");
		clear();

	footer code:
		println("---");
		println("Progam finished.");

	student code:
		println(math.e);
