### PR TITLE
feat: adding option for action visibility

### DIFF
--- a/src/actions/code.js
+++ b/src/actions/code.js
@@ -37,6 +37,7 @@ import {
   postAppInstanceResource,
 } from './appInstanceResources';
 import { openInputPrompt } from './layout';
+import { DEFAULT_VISIBILITY } from '../config/settings';
 
 const flagRunningCode = flag(FLAG_RUNNING_CODE);
 const flagRegisteringWorker = flag(FLAG_REGISTERING_WORKER);
@@ -199,6 +200,7 @@ const runCode = job => (dispatch, getState) => {
         settings: {
           // fallback to defaults
           programmingLanguage = DEFAULT_PROGRAMMING_LANGUAGE,
+          visibility = DEFAULT_VISIBILITY,
           headerCode = '',
           footerCode = '',
         },
@@ -271,6 +273,7 @@ const runCode = job => (dispatch, getState) => {
           headerCode: headerCode || undefined,
           footerCode: footerCode || undefined,
         },
+        visibility,
       })
     );
 
@@ -295,6 +298,7 @@ const saveCode = ({ currentCode }) => (dispatch, getState) => {
         settings: {
           // fallback to defaults
           programmingLanguage = DEFAULT_PROGRAMMING_LANGUAGE,
+          visibility = DEFAULT_VISIBILITY,
         },
       },
     },
@@ -347,6 +351,7 @@ const saveCode = ({ currentCode }) => (dispatch, getState) => {
         programmingLanguage,
         code: currentCode,
       },
+      visibility,
     })
   );
 

--- a/src/components/layout/MaximizableView.js
+++ b/src/components/layout/MaximizableView.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactGa from 'react-ga';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/styles';
 import {
   Fullscreen as FullscreenIcon,
@@ -12,6 +12,7 @@ import Fab from '@material-ui/core/Fab';
 import useFullscreenStatus from '../../hooks/useFullscreenStatus';
 import { postAction } from '../../actions/action';
 import { MAXIMIZED, MINIMIZED } from '../../config/verbs';
+import { DEFAULT_VISIBILITY } from '../../config/settings';
 
 const useStyles = makeStyles(theme => ({
   fab: {
@@ -26,7 +27,9 @@ function MaximizableView({ children }) {
   const maximizableElement = React.useRef(null);
   let isFullscreen;
   let setIsFullscreen;
-
+  const visibility = useSelector(
+    state => state.appInstance.content.settings.visibility || DEFAULT_VISIBILITY
+  );
   const classes = useStyles();
   const dispatch = useDispatch();
 
@@ -51,6 +54,7 @@ function MaximizableView({ children }) {
     dispatch(
       postAction({
         verb: isFullscreen ? MINIMIZED : MAXIMIZED,
+        visibility,
       })
     );
 

--- a/src/components/modes/student/StudentButtons.js
+++ b/src/components/modes/student/StudentButtons.js
@@ -18,6 +18,7 @@ import { FEEDBACK, INPUT } from '../../../config/appInstanceResourceTypes';
 import { getContext, runCode, saveCode } from '../../../actions';
 import { postAction } from '../../../actions/action';
 import { VIEWED } from '../../../config/verbs';
+import { DEFAULT_VISIBILITY } from '../../../config/settings';
 
 class StudentButtons extends Component {
   static styles = theme => ({
@@ -52,6 +53,7 @@ class StudentButtons extends Component {
     dispatchSaveCode: PropTypes.func.isRequired,
     dispatchPostAction: PropTypes.func.isRequired,
     dispatchGetContext: PropTypes.func.isRequired,
+    visibility: PropTypes.string.isRequired,
     currentCode: PropTypes.string.isRequired,
     savedCode: PropTypes.string,
     codeActivity: PropTypes.bool.isRequired,
@@ -90,7 +92,12 @@ class StudentButtons extends Component {
   };
 
   handleNavigate = view => {
-    const { dispatchGetContext, dispatchPostAction, history } = this.props;
+    const {
+      dispatchGetContext,
+      dispatchPostAction,
+      history,
+      visibility,
+    } = this.props;
     history.push(`index.html${addQueryParamsToUrl({ view })}`);
     dispatchGetContext();
     dispatchPostAction({
@@ -98,6 +105,7 @@ class StudentButtons extends Component {
       data: {
         view,
       },
+      visibility,
     });
     ReactGa.event({
       category: 'code',
@@ -196,11 +204,17 @@ class StudentButtons extends Component {
   }
 }
 
-const mapStateToProps = ({ context, appInstanceResources, code }) => {
+const mapStateToProps = ({
+  context,
+  appInstanceResources,
+  code,
+  appInstance,
+}) => {
   const { userId, offline, appInstanceId } = context;
   const inputResource = appInstanceResources.content.find(({ user, type }) => {
     return user === userId && type === INPUT;
   });
+  const { visibility = DEFAULT_VISIBILITY } = appInstance.content.settings;
   const feedbackResource = appInstanceResources.content.find(
     ({ user, type }) => {
       return user === userId && type === FEEDBACK;
@@ -210,6 +224,7 @@ const mapStateToProps = ({ context, appInstanceResources, code }) => {
   return {
     offline,
     appInstanceId,
+    visibility,
     feedback: feedbackResource && feedbackResource.data,
     mode: context.mode,
     view: context.view,

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -40,7 +40,8 @@ export const MAX_NUM_FILES = 10;
 // ten megabytes times 1024 kilobytes/megabyte * 1024 bytes/kilobyte
 export const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-export const DEFAULT_VISIBILITY = 'private';
 export const PUBLIC_VISIBILITY = 'public';
+export const PRIVATE_VISIBILITY = 'private';
+export const DEFAULT_VISIBILITY = PRIVATE_VISIBILITY;
 
 export { DEFAULT_API_HOST };

--- a/src/reducers/appInstance.js
+++ b/src/reducers/appInstance.js
@@ -9,13 +9,14 @@ import {
 } from '../types';
 import { showErrorToast } from '../utils/toasts';
 import { DEFAULT_PROGRAMMING_LANGUAGE } from '../config/programmingLanguages';
-import { DEFAULT_ORIENTATION } from '../config/settings';
+import { DEFAULT_ORIENTATION, DEFAULT_VISIBILITY } from '../config/settings';
 
 const DEFAULT_SETTINGS = {
   programmingLanguage: DEFAULT_PROGRAMMING_LANGUAGE,
   orientation: DEFAULT_ORIENTATION,
   headerCode: '',
   footerCode: '',
+  visibility: DEFAULT_VISIBILITY,
 };
 
 const INITIAL_STATE = {


### PR DESCRIPTION
This pull request is to create an option to change the visibility of the actions created.

Teacher view change the settings (below figures): 
![image](https://user-images.githubusercontent.com/45897168/88373117-e729ec80-cd9f-11ea-80fa-89ffffaf6201.png)

The actions stored by this app should have visibility public once it is chosen by the teacher:
![image](https://user-images.githubusercontent.com/45897168/88393126-d5f3d680-cdc5-11ea-8719-d614b12c4de0.png)


